### PR TITLE
Fixed statusbar padding values

### DIFF
--- a/overlay/frameworks/base/packages/SystemUI/res/values-sw372dp/dimens.xml
+++ b/overlay/frameworks/base/packages/SystemUI/res/values-sw372dp/dimens.xml
@@ -16,6 +16,6 @@
 */
 -->
 <resources>
-    <dimen name="rounded_corner_radius">4dp</dimen>
-    <dimen name="rounded_corner_content_padding">8dp</dimen>
+    <dimen name="rounded_corner_radius">8dp</dimen>
+    <dimen name="rounded_corner_content_padding">4dp</dimen>
 </resources>


### PR DESCRIPTION
It looks like these should be the other way around in terms of values - 8/4 instead of 4/8.